### PR TITLE
fix variable declaration for fs in host builtins check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Just like with dynamic import, with a synchronous import, it's possible to check
 For example, checking if host builtins are available:
 
 ```js
+let fs;
 try {
-  let fs = import.sync('node:fs');
+  fs = import.sync('node:fs');
 } catch {}
 
 if (fs) {


### PR DESCRIPTION
### Description

This pull request addresses an issue with the variable declaration of `fs` in the host builtins availability check. 

### Changes Made
- Updated the declaration of the `fs` variable from `let fs` inside the try block to `fs =` to ensure that the variable is properly scoped and accessible outside the try-catch block.
