### PR TITLE
remove unused link reference for ESM Phase Imports in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,3 @@ To guarantee that a graph is sync upfront, instead see see the [Module Sync Asse
 _Post an [issue](https://github.com/guybedford/proposal-import-sync/issues)._
 
 [Defer Import Eval]: https://github.com/tc39/proposal-defer-import-eval
-[ESM Phase Imports]: https://github.com/tc39/proposal-esm-phase-imports


### PR DESCRIPTION
This pull request removes the unused link reference for "ESM Phase Imports" from the `README.md` file to clean up the documentation and eliminate warnings from Markdown linters.